### PR TITLE
Update gclone to v1.58.0-coffee

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,14 @@ ENV DEBIAN_FRONTEND noninteractive
 # sets the TimeZone, to be used inside the container
 ENV TZ Asia/Kolkata
 
-# rclone ,gclone and fclone
+# rclone and fclone
 RUN curl https://rclone.org/install.sh | bash && \
     aria2c https://github.com/mawaya/rclone/releases/download/fclone-v0.4.1/fclone-v0.4.1-linux-amd64.zip && \
     unzip fclone-v0.4.1-linux-amd64.zip && mv fclone-v0.4.1-linux-amd64/fclone /usr/bin/ && chmod +x /usr/bin/fclone && rm -r fclone-v0.4.1-linux-amd64
 
-# gclone latest
-RUN aria2c https://github.com/dogbutcat/gclone/releases/download/v1.57.0-mod1.4.0/gclone-v1.57.0-mod1.4.0-linux-amd64.zip && \
-    unzip gclone-v1.57.0-mod1.4.0-linux-amd64.zip && mv gclone-v1.57.0-mod1.4.0-linux-amd64/gclone /usr/bin && chmod +x /usr/bin/gclone && rm -r gclone-v1.57.0-mod1.4.0-linux-amd64
+# gclone v1.58.0-coffee
+RUN aria2c https://github.com/l3v11/gclone/releases/download/v1.58.0-coffee/gclone-v1.58.0-coffee-linux-amd64.zip && \
+    unzip gclone-v1.58.0-coffee-linux-amd64.zip && mv gclone-v1.58.0-coffee-linux-amd64/gclone /usr/bin && chmod +x /usr/bin/gclone && rm -r gclone-v1.58.0-coffee-linux-amd64
 
 #drive downloader
 RUN curl -L https://github.com/jaskaranSM/drivedlgo/releases/download/1.5/drivedlgo_1.5_Linux_x86_64.gz -o drivedl.gz && \


### PR DESCRIPTION
- This changes gclone to use v.1.58.0-coffee version from https://github.com/l3v11/gclone